### PR TITLE
Add missing index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./distribute/slider.js');
+module.exports = 'chasselberg.slider';


### PR DESCRIPTION
This makes it possible to require the slider to be used in a browserify project.
